### PR TITLE
Fix responsive UI layout for Age Calculator gap mode

### DIFF
--- a/src/utilities/age-calculator/AgeCalculator.tsx
+++ b/src/utilities/age-calculator/AgeCalculator.tsx
@@ -231,7 +231,7 @@ const AgeCalculator: React.FC = () => {
         </button>
       </div>
 
-      <div style={{ display: 'grid', gridTemplateColumns: mode === 'gap' ? '1fr 1fr' : '1fr', gap: '1.5rem', marginBottom: '2.5rem' }}>
+      <div className={mode === 'gap' ? 'responsive-grid-2' : ''} style={{ display: mode === 'gap' ? undefined : 'grid', gridTemplateColumns: mode === 'gap' ? undefined : '1fr', gap: mode === 'gap' ? undefined : '1.5rem', marginBottom: '2.5rem' }}>
         <CustomDateInput
           label={mode === 'birthday' ? 'Date of Birth' : 'Start Date'}
           value={date1}


### PR DESCRIPTION
Fixes a responsive UI alignment issue in the Age Calculator utility where the "Start Date" and "End Date" inputs would squish and overflow horizontally on mobile screens in "Date Gap Mode". The container now utilizes a CSS class (`responsive-grid-2`) instead of hardcoded inline styles to ensure proper stacking on smaller viewports.

---
*PR created automatically by Jules for task [8364408538295597556](https://jules.google.com/task/8364408538295597556) started by @lalitmahajn*